### PR TITLE
Reorganization of the CI

### DIFF
--- a/.ci/install.plumed
+++ b/.ci/install.plumed
@@ -8,84 +8,92 @@ version=""
 repo=https://github.com/plumed/plumed2.git
 program_name=plumed
 
-for opt
-do
-case "$opt" in
-  (version=*) version="${opt#version=}" ;;
-  (suffix=*)
-     suffix="--program-suffix=${opt#suffix=}"
-     program_name="plumed${opt#suffix=}"
-   ;;
-  (repo=*) repo="${opt#repo=}" ;;
-  (*) echo "unknown option $opt" ; exit 1 ;;
-esac
+for opt; do
+  case "$opt" in
+  version=*) version="${opt#version=}" ;;
+  suffix=*)
+    suffix="--program-suffix=${opt#suffix=}"
+    program_name="plumed${opt#suffix=}"
+    ;;
+  repo=*) repo="${opt#repo=}" ;;
+  *)
+    echo "unknown option $opt"
+    exit 1
+    ;;
+  esac
 done
 
-cd "$(mktemp -dt plumed.XXXXXX)"
+cd "$(mktemp -dt plumed.XXXXXX)" || {
+  echo "Failed to create tempdir"
+  exit 1
+}
 
 git clone $repo
 cd plumed2
 
-if [ -n "$version" ] ; then
+if [[ -n "$version" ]]; then
   echo "installing plumed $version"
 else
-  version=$(git tag --sort=-creatordate | grep '^v2\.[0-9][0-9]*\.[0-9][0-9]*' | head -n 1 )
+  version=$(git tag --sort=version:refname |
+    grep '^v2\.[0-9][0-9]*\.[0-9][0-9]*' |
+    tail -n 1)
   echo "installing latest stable plumed $version"
 fi
 
-# This gets all the dependency information in plumed
-n=0
-nlines=`ls src/*/Makefile | wc -l`
-echo { > $GITHUB_WORKSPACE/_data/extradeps$version.json
-for mod in `ls src/*/Makefile` ;  do 
-    n=$((n+1))
-    dep=`grep USE $mod | sed -e 's/USE=//'`
-    modname=`echo $mod | sed -e 's/src\///' | sed -e 's/\/Makefile//'`
-    typename=`echo $mod | sed -e 's/Makefile/module.type/'`
-    if [ ! -f $typename ] ; then
-         modtype="always"
-    else
-         modtype=`head $typename`
-    fi
-    deparr=($dep)
-    echo \"$modname\" : { >> $GITHUB_WORKSPACE/_data/extradeps$version.json
-    echo \"type\": \"$modtype\", >> $GITHUB_WORKSPACE/_data/extradeps$version.json
-    echo -n \"depends\" : [ >> $GITHUB_WORKSPACE/_data/extradeps$version.json
-    for d in ${deparr[@]} ; do
-        if [ $d == ${deparr[0]} ] ; then
-           echo -n \"$d\" >> $GITHUB_WORKSPACE/_data/extradeps$version.json
-        else 
-           echo -n , \"$d\" >> $GITHUB_WORKSPACE/_data/extradeps$version.json
-        fi
-    done
-    if [ $n == $nlines ] ; then
-      echo ] >> $GITHUB_WORKSPACE/_data/extradeps$version.json
-      echo } >> $GITHUB_WORKSPACE/_data/extradeps$version.json
-    else
-      echo ] >> $GITHUB_WORKSPACE/_data/extradeps$version.json
-      echo }, >> $GITHUB_WORKSPACE/_data/extradeps$version.json
-    fi
-done
-echo } >> $GITHUB_WORKSPACE/_data/extradeps$version.json
-
+#cheking out to $version before compiling the dependency json for this $version
 git checkout $version
+
+# This gets all the dependency information in plumed
+{
+  firstline=""
+  echo '{'
+  for mod in src/*/Makefile; do
+    dir=${mod%/*}
+    modname=${dir##*/}
+    typename=$dir/module.type
+
+    if [[ ! -f $typename ]]; then
+      modtype="always"
+    else
+      modtype=$(head "$typename")
+    fi
+    dep=$(grep USE "$mod" | sed -e 's/USE=//')
+
+    IFS=" " read -r -a deparr <<<"$dep"
+    echo -e "${firstline}\"$modname\" : {"
+    echo "\"type\": \"$modtype\","
+    echo -n '"depends" : ['
+    pre=""
+    for d in "${deparr[@]}"; do
+      echo -n "${pre}\"$d\""
+      pre=", "
+    done
+    echo ']'
+    echo -n '}'
+    firstline=",\n"
+  done
+  echo -e '\n}'
+} >"$GITHUB_WORKSPACE/_data/extradeps$version.json"
 
 hash=$(git rev-parse HEAD)
 
-if test -f $HOME/opt/lib/$program_name/$hash
-then
+if [[ -f $HOME/opt/lib/$program_name/$hash ]]; then
   echo "ALREADY AVAILABLE, NO NEED TO REINSTALL"
 else
 
-rm -fr $HOME/opt/lib/$program_name
-rm -fr $HOME/opt/bin/$program_name
-rm -fr $HOME/opt/include/$program_name
-rm -fr $HOME/opt/lib/lib$program_name.so*
+  rm -fr "$HOME/opt/lib/$program_name"
+  rm -fr "$HOME/opt/bin/$program_name"
+  rm -fr "$HOME/opt/include/$program_name"
+  rm -fr "$HOME"/opt/lib/lib$program_name.so*
 
-./configure --prefix=$HOME/opt  --enable-modules=all --enable-boost_serialization --enable-fftw $suffix --enable-libtorch LDFLAGS=-Wl,-rpath,$LD_LIBRARY_PATH
-make -j 5
-make install
+  ./configure --prefix="$HOME/opt" \
+    --enable-modules=all \
+    --enable-boost_serialization \
+    --enable-fftw $suffix \
+    --enable-libtorch LDFLAGS=-Wl,-rpath,$LD_LIBRARY_PATH
+  make -j 5
+  make install
 
-touch $HOME/opt/lib/$program_name/$hash
+  touch "$HOME/opt/lib/$program_name/$hash"
 
 fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,33 +1,88 @@
-# This is a basic workflow to help you get started with Actions
+name: CI - plumed tutorials -
 
-name: CI
-
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on: [push, pull_request]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a job called "build"
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: calculate cache key for the compilation
+        id: get-key
+        run: |
+          git clone --bare https://github.com/plumed/plumed2.git
+          stable=$(cd plumed2.git ; git branch --list 'v2.*' --sort='version:refname'| sed "s/^ *//" | grep '^v2\.[0-9]*$' | tail -n 1)
+          echo "key=$(cd plumed2.git ; git rev-parse "$stable")-$(cd plumed2.git ; git rev-parse master)" >> $GITHUB_OUTPUT
+
+      - name: setting up or retrieving the compilation cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/opt
+            ~/.ccache
+          key: ccache-${{ runner.os }}-${{ steps.get-key.outputs.key }}
+          restore-keys: ccache-${{ runner.os }}-
+
+      - name: Set paths
+        run: |
+              echo "$HOME/opt/bin" >> $GITHUB_PATH
+              echo "CPATH=$HOME/opt/include:$HOME/opt/libtorch/include/torch/csrc/api/include/:$HOME/opt/libtorch/include/:$HOME/opt/libtorch/include/torch:$CPATH" >> $GITHUB_ENV
+              echo "INCLUDE=$HOME/opt/include:$HOME/opt/libtorch/include/torch/csrc/api/include/:$HOME/opt/libtorch/include/:$HOME/opt/libtorch/include/torch:$INCLUDE" >> $GITHUB_ENV
+              echo "LIBRARY_PATH=$HOME/opt/lib:$HOME/opt/libtorch/lib:$LIBRARY_PATH" >> $GITHUB_ENV
+              echo "LD_LIBRARY_PATH=$HOME/opt/lib:$HOME/opt/libtorch/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+              echo "PYTHONPATH=$HOME/opt/lib/plumed/python:$PYTHONPATH" >> $GITHUB_ENV
+              # needed to avoid MPI warning
+              echo "OMPI_MCA_btl=^openib" >> $GITHUB_ENV
+      - name: Install software
+        run: |
+            sudo apt update
+            sudo apt install mpi-default-bin mpi-default-dev
+            sudo apt install libfftw3-dev gsl-bin libgsl0-dev libboost-serialization-dev
+            sudo apt install ccache
+            sudo apt-get update
+            sudo ln -s ccache /usr/local/bin/mpic++
+            export PATH=/usr/lib/ccache:${PATH}
+            ccache -s
+            .ci/install.libtorch
+            # version=master or version=f123f12f3 to select a specific version
+            # The ordering is by version, so 2.10 will be > than 2.1 
+            CXX="mpic++" .ci/install.plumed version="$(cd plumed2.git ; git branch --list 'v2.*' --sort='version:refname'| sed "s/^ *//" | grep '^v2\.[0-9]*$' | tail -n 1)" repo=$PWD/plumed2.git
+            # GB: in addition, we install master version as plumed_master
+            CXX="mpic++" .ci/install.plumed version=master suffix=_master repo=$PWD/plumed2.git
+            ccache -s
+      - name: caches the install results
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/opt
+            ./_data
+          key: build-${{ runner.os }}-${{ github.sha }}
+
   build:
+    needs: setup
     strategy:
       matrix:
         replica: [0, 1]
-    # The type of runner that the job will run on
+        # I'd wish to use something like ${{ strategy.job-total }} the get the 
+        #number of current jobs of the matrix, but things could go wrong in case
+        #of adding a "special" strategy or something similar.
+        # with env: REPLICAS there are 2 things to change (replica and REPLICAS),
+        #but at a least no need to update a line that can be lost further in the yaml
+    env:
+      REPLICAS: 2
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+
     - uses: actions/checkout@v4
 
-    - uses: actions/cache@v4
+    - uses: actions/cache/restore@v4
       with:
         path: |
           ~/opt
-          ~/.ccache
-        key: ccache-${{ runner.os }}-${{ github.sha }}
-        restore-keys: ccache-${{ runner.os }}-
+          ./_data
+        key: build-${{ runner.os }}-${{ github.sha }}
+        fail-on-cache-miss: true
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v5
@@ -49,32 +104,21 @@ jobs:
     - name: Install software
       run: |
         sudo apt update
+        #shall we get non-dev version of these?
         sudo apt install mpi-default-bin mpi-default-dev
         sudo apt install libfftw3-dev gsl-bin libgsl0-dev libboost-serialization-dev
-        sudo apt install ccache
         sudo apt-get update
         pip install -r requirements.txt
-        git clone --bare https://github.com/plumed/plumed2.git
-        sudo ln -s ccache /usr/local/bin/mpic++
-        export PATH=/usr/lib/ccache:${PATH}
-        ccache -s
-        .ci/install.libtorch
-        # version=master or version=f123f12f3 to select a specific version
-        # The ordering is by version, so 2.10 will be > than 2.1 
-        CXX="mpic++" .ci/install.plumed version="$(cd plumed2.git ; git branch --list 'v2.*' --sort='version:refname'| sed "s/^ *//" | grep '^v2\.[0-9]*$' | tail -n 1)" repo=$PWD/plumed2.git
-        # GB: in addition, we install master version as plumed_master
-        CXX="mpic++" .ci/install.plumed version=master suffix=_master repo=$PWD/plumed2.git
-        ccache -s
     - name: Build manual
       run: | 
         python --version
         # N.B. If you adjust the number of replicas used here you need to adjust the liquid syntax in summary.md that builds the total number of lessons that use each action 
-        python build_manual.py --nreplicas 2 --replica ${{matrix.replica}}
-    - name: Run
+        python build_manual.py --nreplicas $REPLICAS --replica ${{matrix.replica}}
+    - name: Compile lessons
       run: |
         python --version
         # N.B. If you adjust the number of replicas used here you need to adjust the liquid syntax in summary.md that builds the total number of lessons that use each action 
-        python compile.py --nreplicas 2 --replica ${{matrix.replica}}
+        python compile.py --nreplicas $REPLICAS --replica ${{matrix.replica}}
         cp $(plumed info --root)/json/syntax.json syntax.${{matrix.replica}}.json
     - name: Create tar ball
       run: |
@@ -93,12 +137,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
     - name: Download artifacts
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/opt
@@ -30,7 +30,7 @@ jobs:
         restore-keys: ccache-${{ runner.os }}-
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
 
@@ -89,7 +89,7 @@ jobs:
         tar cf lessons.tar $(find . -name "*.pdf") $(find . -name "*.png") $(find . -name "*.gif") $(find . -name "*.md") $(find . -name "*.stdout.txt.zip") $(find . -name "*.stderr.txt.zip") $(find . -name ".svg") $(find . -name "*.html") _data/*.yml _data/*.json
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: lesson-content${{matrix.replica}}
         path: lessons.tar 
@@ -104,11 +104,11 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Download artifacts
       uses: actions/download-artifact@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install software

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.8
+        cache: pip
 
     - name: Set paths
       run: |
@@ -52,16 +53,7 @@ jobs:
         sudo apt install libfftw3-dev gsl-bin libgsl0-dev libboost-serialization-dev
         sudo apt install ccache
         sudo apt-get update
-        pip install PyYAML pytz
-        pip install nbconvert
-        pip install nbformat
-        pip install requests
-        pip install bs4
-        pip install PlumedToHTML
-        pip install networkx
-        pip install numpy
-        pip install pytube
-        pip install DateTime
+        pip install -r requirements.txt
         git clone --bare https://github.com/plumed/plumed2.git
         sudo ln -s ccache /usr/local/bin/mpic++
         export PATH=/usr/lib/ccache:${PATH}
@@ -111,10 +103,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.8
+        cache: 'pip'
+
     - name: Install software
       run: |
-        pip install PyYAML pytz
-        pip install networkx
+        grep 'PyYAML\|pytz\|networkx' requirements.txt > requirements-upload.txt
+        pip install -r requirements-upload.txt
+        
     - name: Create graph
       run: |
         python create_graph.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,8 +60,8 @@ jobs:
         ccache -s
         .ci/install.libtorch
         # version=master or version=f123f12f3 to select a specific version
-        # pick newest release branch (alphabetic, will fail at v2.10)
-        CXX="mpic++" .ci/install.plumed version="$(cd plumed2.git ; git branch | sed "s/^ *//" | grep '^v2\.[0-9]$' | tail -n 1)" repo=$PWD/plumed2.git
+        # The ordering is by version, so 2.10 will be > than 2.1 
+        CXX="mpic++" .ci/install.plumed version="$(cd plumed2.git ; git branch --list 'v2.*' --sort='version:refname'| sed "s/^ *//" | grep '^v2\.[0-9]*$' | tail -n 1)" repo=$PWD/plumed2.git
         # GB: in addition, we install master version as plumed_master
         CXX="mpic++" .ci/install.plumed version=master suffix=_master repo=$PWD/plumed2.git
         ccache -s
@@ -98,7 +98,7 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v6
     - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+PyYAML==6.0.2
+pytz==2024.1
+nbconvert==7.16.4
+nbformat==5.10.4
+requests==2.32.3
+bs4==0.0.2
+PlumedToHTML==0.73
+networkx==3.1
+numpy==1.24.4
+pytube==15.0.0
+DateTime==5.5


### PR DESCRIPTION
I changed a few things in the CI:
 - the versions of the actions called now are up-to-date with the recommendations from GH
 - I added the caching for the python installation, and this should make possible to start setting up a local test for each of the single lessons, thanks to the added `requirements.txt`
   - `requirements.txt` is full of "==" because its hash is used to store the pip cache
 - I future-proofed the CI's yaml for the incoming stable 2.10
 - `.ci/install.plumed` has been [shellchecked](https://www.shellcheck.net/)
 - I changed how the compile cache works to avoid conflicts in the parallel part of the job, moreover, if the school fails to compile but the plumed compilation has gone well, the plumed compilation will still be cached (saving 15~20 mins). I also added a "build" cache with only the _data and the opt directories.
 

