### PR TITLE
Added the possibility to run locally a lesson for test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#Extrafiles in _data, due to compile.py
+_data/lessons*.yml
+_data/plumed.yml
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/compile.py
+++ b/compile.py
@@ -17,6 +17,9 @@ from PlumedToHTML import test_plumed, get_html, get_mermaid
 if not (sys.version_info > (3, 0)):
    raise RuntimeError("We are using too many python 3 constructs, so this is only working with python 3")
 
+PLUMED_STABLE="plumed"
+PLUMED_MASTER="plumed_master"
+
 @contextmanager
 def cd(newdir):
     prevdir = os.getcwd()
@@ -164,9 +167,9 @@ def processMarkdown( filename, actions ) :
             if usemermaid!="" :
                mermaidinpt = ""
                if usemermaid=="value" :
-                  mermaidinpt = get_mermaid( "plumed_master", plumed_inp, False )
+                  mermaidinpt = get_mermaid( PLUMED_MASTER, plumed_inp, False )
                elif usemermaid=="force" :
-                  mermaidinpt = get_mermaid( "plumed_master", plumed_inp, True )
+                  mermaidinpt = get_mermaid( PLUMED_MASTER, plumed_inp, True )
                else :
                   raise RuntimeError(usemermaid + "is invalid instruction for use mermaid") 
                ofile.write("```mermaid\n" + mermaidinpt + "\n```\n")
@@ -190,20 +193,20 @@ def processMarkdown( filename, actions ) :
                      sf.write( plumed_inp )
 
             # Test whether the input solution can be parsed
-            success = success=test_plumed( "plumed", "data/" + solutionfile )
+            success = success=test_plumed( PLUMED_STABLE, "data/" + solutionfile )
             if(success!=0 and success!="custom") : nfail = nfail + 1
             # Json files are put in directory one up from us to ensure that
             # PlumedToHTML finds them when we do get_html (i.e. these will be in
             # the data directory where the calculation is run)
             if incomplete :
-               success_master=test_plumed("plumed_master", "data/" + solutionfile ) 
+               success_master=test_plumed(PLUMED_MASTER, "data/" + solutionfile ) 
             else :
-               success_master=test_plumed("plumed_master", "data/" + solutionfile,
+               success_master=test_plumed(PLUMED_MASTER, "data/" + solutionfile,
                                           printjson=True, jsondir="../" )
             if( success_master!=0 and success_master!="custom") :
                nfailm = nfailm + 1
             # Find the stable version 
-            stable_version=subprocess.check_output('plumed info --version',
+            stable_version=subprocess.check_output(f'{PLUMED_STABLE} info --version',
                                                    shell=True).decode('utf-8').strip()
             # Use PlumedToHTML to create the input with all the bells and whistles
             html = get_html(plumed_inp,
@@ -211,7 +214,7 @@ def processMarkdown( filename, actions ) :
                               solutionfile,
                               ("v"+ stable_version,"master"),
                               (success,success_master),
-                              ("plumed","plumed_master"),
+                              (PLUMED_STABLE,PLUMED_MASTER),
                               usejson=(not success_master),
                               actions=actions )
             # Print the html for the solution
@@ -349,12 +352,12 @@ if __name__ == "__main__":
           replica = int(arg)
     print("RUNNING", nreplicas, "REPLICAS. THIS IS REPLICA", replica )
     # write plumed version to file
-    stable_version=subprocess.check_output('plumed info --version', shell=True).decode('utf-8').strip()
+    stable_version=subprocess.check_output(f'{PLUMED_STABLE} info --version', shell=True).decode('utf-8').strip()
     f=open("_data/plumed.yml","w")
     f.write("stable: v%s" % str(stable_version))
     f.close()
     # Get list of plumed actions from syntax file
-    cmd = ['plumed_master', 'info', '--root']
+    cmd = [PLUMED_MASTER, 'info', '--root']
     plumed_info = subprocess.run(cmd, capture_output=True, text=True )
     keyfile = plumed_info.stdout.strip() + "/json/syntax.json" 
     with open(keyfile) as f :

--- a/lessons/.gitignore
+++ b/lessons/.gitignore
@@ -1,0 +1,4 @@
+#the only files that we want to store is this .gitignore and the lesson settings
+!lesson.yml
+!.gitignore
+*

--- a/testLesson.py
+++ b/testLesson.py
@@ -1,0 +1,35 @@
+# this is using ruff==0.6.2 to check that the code won't explode badly
+# pip install ruff==0.6.2
+# ruff format testLesson.py
+# ruff check testLesson.py
+from compile import process_lesson
+
+DEFAULT_PLUMED = "plumed"
+if __name__ == "__main__":
+    import subprocess
+    import json
+    import sys
+
+    # args here:
+    # first "naked" argument is the path to lesson.y(a)ml
+    plumed_to_use = DEFAULT_PLUMED
+    cmd = [plumed_to_use, "info", "--root"]
+    plumed_info = subprocess.run(cmd, capture_output=True, text=True)
+    keyfile = plumed_info.stdout.strip() + "/json/syntax.json"
+
+    with open(keyfile) as f:
+        try:
+            plumed_syntax = json.load(f)
+        except ValueError as ve:
+            raise json.InvalidJSONError(ve)
+
+    action_counts = {}
+    for key in plumed_syntax:
+        if key == "vimlink" or key == "replicalink" or key == "groups":
+            continue
+        action_counts[key] = 0
+
+    lessonPath = sys.argv[1]
+    if "lesson.yml" in lessonPath:
+        lessonPath = lessonPath.replace("lesson.yml", "")
+    process_lesson(sys.argv[1], action_counts, plumed_syntax)


### PR DESCRIPTION
@gtribello I added an extra script to test the lessons locally, one at a time, without a --help, I think that it needs some more functionalities

I added the 
```python
PLUMED_MASTER="plumed_master"
PLUMED_STABLE="plumed"
```
modifications from #6, so that you can change on the fly "plumed_master" to "plumed" and run your instance of testLesson with fewer risks




