### PR TITLE
Correction Yvalues in  summary.md

### DIFF
--- a/summary.md
+++ b/summary.md
@@ -45,7 +45,7 @@ The chart below shows how many lessons make use of each of the available actions
 
 <script id="actionChart">
 var xValues = [ {{ actionlist | join: '", "' | prepend: '"' | append: '"' }} ];
-var yValues = [ {{ astr }} ];
+var yValues = [ {{ actionno   | join: ', '}} ];
 // do sorting in descending order based on yValues
 //1) combine the arrays:
 var list = [];


### PR DESCRIPTION
The chart had empty yvalues, this should correct my mistake (the code is identical to the one in the nest)

We should embed the common parts in Plumed2HTML to have everything available in both the sites, shall I start @gtribello?